### PR TITLE
Option to select columns in explain_outlier() for COPOD model

### DIFF
--- a/pyod/models/copod.py
+++ b/pyod/models/copod.py
@@ -217,7 +217,7 @@ class COPOD(BaseDetector):
             decision_scores_ = self.O.sum(axis=1).to_numpy()
         return decision_scores_.ravel()
 
-    def explain_outlier(self, ind, cutoffs=None,
+    def explain_outlier(self, ind, columns=None, cutoffs=None,
                         feature_names=None):  # pragma: no cover
         """Plot dimensional outlier graph for a given data
             point within the dataset.
@@ -226,6 +226,10 @@ class COPOD(BaseDetector):
         ind : int
             The index of the data point one wishes to obtain
             a dimensional outlier graph for.
+            
+        columns: list of strings
+            The list of column names from the dataset that should be
+            displayed on the plot. The default are all columns.
         
         cutoffs : list of floats in (0., 1), optional (default=[0.95, 0.99])
             The significance cutoff bands of the dimensional outlier graph.
@@ -239,20 +243,26 @@ class COPOD(BaseDetector):
         Plot : matplotlib plot
             The dimensional outlier graph for data point with index ind.
         """
+        if columns is None:
+            columns = self.O.columns
+            column_range = range(1, self.O.shape[1] + 1)
+        else:
+            column_range = range(1, len(columns) + 1)
+
         cutoffs = [1 - self.contamination,
                    0.99] if cutoffs is None else cutoffs
-        plt.plot(range(1, self.O.shape[1] + 1), self.O.iloc[ind],
+        plt.plot(column_range, self.O.loc[ind, columns],
                  label='Outlier Score')
         for i in cutoffs:
-            plt.plot(range(1, self.O.shape[1] + 1),
-                     self.O.quantile(q=i, axis=0), '-',
+            plt.plot(column_range,
+                     self.O.loc[:, columns].quantile(q=i, axis=0), '-',
                      label='{percentile} Cutoff Band'.format(percentile=i))
-        plt.xlim([1, self.O.shape[1] + 1])
-        plt.ylim([0, int(self.O.max().max()) + 1])
+        plt.xlim([1, max(column_range)])
+        plt.ylim([0, int(self.O.loc[:, columns].max().max()) + 1])
         plt.ylabel('Dimensional Outlier Score')
         plt.xlabel('Dimension')
 
-        ticks = range(1, self.O.shape[1] + 1)
+        ticks = column_range
         if feature_names is not None:
             assert len(feature_names) == len(ticks), \
                 "Length of feature_names does not match dataset dimensions."
@@ -260,12 +270,12 @@ class COPOD(BaseDetector):
         else:
             plt.xticks(ticks)
 
-        plt.yticks(range(0, int(self.O.max().max()) + 1))
+        plt.yticks(range(0, int(self.O.loc[:, columns].max().max()) + 1))
         label = 'Outlier' if self.labels_[ind] == 1 else 'Inlier'
         plt.title('Outlier Score Breakdown for Data #{index} ({label})'.format(
             index=ind + 1, label=label))
         plt.legend()
         plt.show()
-        return self.O.iloc[ind], self.O.quantile(q=cutoffs[0],
-                                                 axis=0), self.O.quantile(
+        return self.O.loc[ind, columns], self.O.loc[:, columns].quantile(q=cutoffs[0],
+                                                 axis=0), self.O.loc[:, columns].quantile(
             q=cutoffs[1], axis=0)


### PR DESCRIPTION
When there are a lot of dimensions, the x axis in explain_outlier() becomes cluttered and impossible to read. This code adds "columns" optional argument where the user can select which exact columns of the dataset should be presented on the plot.

### All Submissions Basics:

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [ ] Have you checked all [Issues](../../issues) to tie the PR to a specific one?

### All Submissions Cores:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
* [ ] Does your submission pass tests, including CircleCI, Travis CI, and AppVeyor?
* [ ] Does your submission have appropriate code coverage? The cutoff threshold is 95% by Coversall.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Model Submissions:

* [ ] Have you created a <NewModel>.py in ~/pyod/models/?
* [ ] Have you created a <NewModel>_example.py in ~/examples/?
* [ ] Have you created a test_<NewModel>.py in ~/pyod/test/?
* [ ] Have you lint your code locally prior to submission?
